### PR TITLE
Fix the hierarchy of the config file

### DIFF
--- a/lib/makara/config_parser.rb
+++ b/lib/makara/config_parser.rb
@@ -157,16 +157,16 @@ module Makara
 
 
     def master_configs
-      all_configs.
-        select{|config| config[:role] == 'master' }.
-        map{|config| config.except(:role) }
+      all_configs
+        .select { |config| config[:role] == 'master' }
+        .map { |config| config.except(:role) }
     end
 
 
     def slave_configs
-      all_configs.
-        reject{|config| config[:role] == 'master' }.
-        map{|config| config.except(:role) }
+      all_configs
+        .reject { |config| config[:role] == 'master' }
+        .map { |config| config.except(:role) }
     end
 
 
@@ -175,7 +175,8 @@ module Makara
 
     def all_configs
       @makara_config[:connections].map do |connection|
-        base_config.merge(connection.symbolize_keys)
+        base_config.merge(makara_config.except(:connections))
+                   .merge(connection.symbolize_keys)
       end
     end
 

--- a/lib/makara/proxy.rb
+++ b/lib/makara/proxy.rb
@@ -141,7 +141,7 @@ module Makara
       @master_pool.provide do |con|
         yield con
       end
-    rescue ::Makara::Errors::AllConnectionsBlacklisted, ::Makara::Errors::NoConnectionsAvailable => e
+    rescue ::Makara::Errors::AllConnectionsBlacklisted, ::Makara::Errors::NoConnectionsAvailable
       begin
         @master_pool.disabled = true
         @slave_pool.provide do |con|
@@ -256,14 +256,14 @@ module Makara
     def instantiate_connections
       @master_pool = Makara::Pool.new('master', self)
       @config_parser.master_configs.each do |master_config|
-        @master_pool.add master_config.merge(@config_parser.makara_config) do
+        @master_pool.add master_config do
           graceful_connection_for(master_config)
         end
       end
 
       @slave_pool = Makara::Pool.new('slave', self)
       @config_parser.slave_configs.each do |slave_config|
-        @slave_pool.add slave_config.merge(@config_parser.makara_config) do
+        @slave_pool.add slave_config do
           graceful_connection_for(slave_config)
         end
       end

--- a/spec/config_parser_spec.rb
+++ b/spec/config_parser_spec.rb
@@ -88,15 +88,73 @@ describe Makara::ConfigParser do
     expect(parsera.id).to eq(parserc.id)
   end
 
-  it 'should provide master and slave configs' do
-    parser = described_class.new(config)
-    expect(parser.master_configs).to eq([
-      {:name => 'themaster', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true}
-    ])
-    expect(parser.slave_configs).to eq([
-      {:name => 'slave1', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true},
-      {:name => 'slave2', :top_level => 'value', :blacklist_duration => 30, :master_ttl => 5, :sticky => true}
-    ])
-  end
+  context 'master and slave configs' do
+    it 'should provide master and slave configs' do
+      parser = described_class.new(config)
+      expect(parser.master_configs).to eq([
+        {
+          :name => 'themaster',
+          :top_level => 'value',
+          :sticky => true,
+          :blacklist_duration => 30,
+          :master_ttl => 5,
+          :sticky => true
+        }
+      ])
+      expect(parser.slave_configs).to eq([
+        {
+          :name => 'slave1',
+          :top_level => 'value',
+          :sticky => true,
+          :blacklist_duration => 30,
+          :master_ttl => 5,
+          :sticky => true
+        },
+        {
+          :name => 'slave2',
+          :top_level => 'value',
+          :sticky => true,
+          :blacklist_duration => 30,
+          :master_ttl => 5,
+          :sticky => true
+        }
+      ])
+    end
 
+    it 'connection configuration should override makara config' do
+      config[:makara][:blacklist_duration] = 123
+      config[:makara][:connections][0][:blacklist_duration] = 456
+      config[:makara][:connections][1][:top_level] = 'slave value'
+
+      parser = described_class.new(config)
+      expect(parser.master_configs).to eq([
+        {
+          :name => 'themaster',
+          :top_level => 'value',
+          :sticky => true,
+          :blacklist_duration => 456,
+          :master_ttl => 5,
+          :sticky => true
+        }
+      ])
+      expect(parser.slave_configs).to eq([
+        {
+          :name => 'slave1',
+          :top_level => 'slave value',
+          :sticky => true,
+          :blacklist_duration => 123,
+          :master_ttl => 5,
+          :sticky => true
+        },
+        {
+          :name => 'slave2',
+          :top_level => 'value',
+          :sticky => true,
+          :blacklist_duration => 123,
+          :master_ttl => 5,
+          :sticky => true
+        }
+      ])
+    end
+  end
 end


### PR DESCRIPTION
The connection level settings were not being given precedence over the makara configuration when getting instantiated. This corrects that behavior by properly prioritizing the merging of the configuration options.

This was uncovered while trying to set the blacklist_duration differently on master than on the slaves.
